### PR TITLE
add_reference support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Gemfile.lock
+*.swp

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 case ENV['DB_NAZI_ADAPTER']

--- a/lib/db_nazi.rb
+++ b/lib/db_nazi.rb
@@ -76,6 +76,11 @@ module DBNazi
           raise IndexUniquenessRequired, "[db_nazi] :unique parameter required"
       end
     end
+
+    def check_reference(options)
+      check_index(options) and
+        self.require_index_uniqueness = false
+    end
   end
 
   reset

--- a/lib/db_nazi/abstract_adapter.rb
+++ b/lib/db_nazi/abstract_adapter.rb
@@ -24,6 +24,11 @@ module DBNazi
         super
       end
 
+      def add_reference(table_name, ref_name, options = {})
+        DBNazi.check_reference(options)
+        super
+      end
+
       def change_column(table_name, column_name, type, options = {})
         DBNazi.check_column(type, options)
         super


### PR DESCRIPTION
@oggy Are you using this gem anymore? I'm using it in a Rails 4 project and wanted to run an `add_reference` migration and couldn't, so this adds support. However, adding unit tests for it is making me run through the usual rigamarole one needs to go through when they run a 3 year old ruby project on a new machine (bumping ActiveRecord and Minitest versions led to bumping temporaries, which led to deprecations which now lead to real failures across the suite :)). Just wondering if I'm the only person on earth using this gem and if I should just go to town on it or if you have thoughts about modernizing.

I hope this finds you well!
